### PR TITLE
Adding support to additional relational databases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,22 @@
             <version>23.3.0.23.09</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.3.232</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/net.snowflake/snowflake-jdbc -->
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc</artifactId>
+            <version>3.19.0</version>
+        </dependency>
+
+
+
         <!--=======================-->
         <!-- Reactive dependencies -->
         <!--=======================-->

--- a/src/main/java/be/ugent/idlab/knows/dataio/access/DatabaseType.java
+++ b/src/main/java/be/ugent/idlab/knows/dataio/access/DatabaseType.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /*
-    NOTE: The Oracle driver has to be installed manually, because it's not on Maven due to licensing.
+    NOTE: The Oracle, Denodo Platform and Athena drivers have to be installed manually, because they are not on Maven due to licensing.
  */
 public enum DatabaseType {
 
@@ -27,7 +27,23 @@ public enum DatabaseType {
     DB2("IBM DB2",
             "as400:",
             "ibm",
-            "com.ibm.as400.access.AS400JDBCDriver");
+            "com.ibm.as400.access.AS400JDBCDriver"),
+    H2("H2",
+            "h2:tcp:",
+            "h2",
+            "org.h2.Driver"),
+    DENODO("Denodo",
+            "vdb:",
+            "denodo",
+            "com.denodo.vdp.jdbc.Driver"),
+    ATHENA("Athena",
+            "awsathena:",
+            "athena",
+            "com.simba.athena.jdbc.Driver"),
+    SNOWFLAKE("Snowflake",
+            "snowflake:",
+            "snowflake",
+            "net.snowflake.client.jdbc.SnowflakeDriver");
 
     private final String name;
     private final String jdbcPrefix;


### PR DESCRIPTION
Support for H2, Denodo Platform, AWS Athena and Snowflake databases. In combination with this support, RDBAccess has been extended so it can support fully JDBC connection properties and propagate them to the driver. This is required for AWS Athena, as additional connection properties are required for a successful connection to this DB.

A new constructor has been created that takes a java.util.Properties instead of the previous combination of username and password. This approach is more flexible, as it allows to also encode whichever key-pair properties are required by the specific JDBC driver in question. Nonetheless, a design approach has been taken to maintain the old constructor in order to keep compatibility with code using the previous approach.

In order to propagate the connection properties correctly from RMLMapper, a small change is required on that project on the AccessFactory class in order to build properties off the R2RML mapping, to add username, password and custom key-pair properties to a java.util.Properties object and propagate it through the new constructor created on RDBAccess.

Additionally, a change to RDBAccess.normalizeData has been done to avoid a NPE when the input data string is null.

