### PR TITLE
Fixing CSVRecord.get when reference does not exist.

### DIFF
--- a/src/main/java/be/ugent/idlab/knows/dataio/record/CSVRecord.java
+++ b/src/main/java/be/ugent/idlab/knows/dataio/record/CSVRecord.java
@@ -80,7 +80,8 @@ public class CSVRecord extends Record {
             toDatabaseCase = reference;
         }
         if (!this.data.containsKey(toDatabaseCase)) {
-            throw new IllegalArgumentException(String.format("Mapping for %s not found, expected one of %s", toDatabaseCase, data.keySet()));
+            logger.warn("Mapping for {} not found, expected one of {}", toDatabaseCase, data.keySet());
+            return List.of();
         }
         String obj = this.data.get(toDatabaseCase);
 


### PR DESCRIPTION
Allowing for graceful failure when a mapping is not found on the data, allowing the execute to carry on ignoring the missing field, instead of stopping the process altogether.